### PR TITLE
feat: add production evaluation patterns, lifecycle, and RAG evaluation structure

### DIFF
--- a/06-production-evaluation-patterns/README.md
+++ b/06-production-evaluation-patterns/README.md
@@ -1,0 +1,10 @@
+# Production Evaluation Patterns
+
+The first question to answer when evaluating an AI agent is: **what type of agent is it?**
+
+We classify agents into two categories based on whether their output has a measurable ground truth:
+
+- **Objective agents** are quantitative. Their outputs can be measured with code or math. There is a correct answer, and you can compute how close the agent got to it. Examples: a classification agent that routes support tickets to departments, a pricing agent that predicts product values, a tagging agent that labels documents into categories, or an extraction agent that pulls structured fields from contracts. You evaluate these the same way a data scientist evaluates a model: accuracy, precision, recall, F1, RMSE, etc.
+- **Subjective agents** are qualitative. Their outputs have no single right answer, and evaluation is more vibes-based. Examples: deep research agents, website builders, slide generators, creative writing assistants. You evaluate these through alignment with human preferences, checklist-based rubrics, and domain expert review.
+
+Start by identifying which category your agent falls into, then navigate into the appropriate folder for specific evaluation strategies and metrics.

--- a/06-production-evaluation-patterns/objective/README.md
+++ b/06-production-evaluation-patterns/objective/README.md
@@ -1,0 +1,10 @@
+# Objective Agents
+
+An objective agent is one where the output has a measurable ground truth. You can write code or apply a formula to determine whether the agent got it right. This is your classical data science evaluation territory.
+
+Subtypes:
+
+- **Single-label classification** - One correct label per item. Accuracy for balanced datasets, F1/precision/recall for imbalanced ones.
+- **Multi-label classification** - Multiple correct labels per item. Document tagging, object detection, or finding the right set of items from a larger pool.
+- **Regression** - Continuous numeric outputs. L2 loss, RMSE.
+- **Structured output with LLM-as-judge** - The output is structured (JSON, schema-conforming) and you use an LLM judge to verify correctness. Still objective because there is something tangible to measure against.

--- a/06-production-evaluation-patterns/objective/multi-label-classification/README.md
+++ b/06-production-evaluation-patterns/objective/multi-label-classification/README.md
@@ -1,0 +1,5 @@
+# Multi-Label Classification
+
+This is when a single input can have multiple correct labels. Examples: tagging a document into several categories, object detection (multiple objects in one image), or finding the right set of chunks in a retrieval system.
+
+The key questions become: how many of the correct labels did you find, and how many of the labels you returned were actually correct? This maps to precision (of the labels returned, how many were right) and recall (of the labels that exist, how many did you find). RAG retrieval evaluation often falls into this pattern: given a query, did you retrieve the right chunks, and did you get all of them?

--- a/06-production-evaluation-patterns/objective/regression/README.md
+++ b/06-production-evaluation-patterns/objective/regression/README.md
@@ -1,0 +1,5 @@
+# Regression
+
+Regression applies when your agent outputs a continuous numeric value. Examples: predicting a price, estimating delivery time, scoring a lead, or forecasting demand.
+
+The standard metrics are L2 loss (mean squared error) and RMSE (root mean squared error). For binary outcomes with probability outputs, log loss applies. The key difference from classification is that being "close" to the right answer matters. Predicting $102 when the answer is $100 is much better than predicting $500.

--- a/06-production-evaluation-patterns/objective/single-label-classification/README.md
+++ b/06-production-evaluation-patterns/objective/single-label-classification/README.md
@@ -1,0 +1,5 @@
+# Single-Label Classification
+
+This is the simplest objective evaluation pattern. Each input maps to exactly one correct label. Examples: sentiment analysis (positive/negative), intent classification, routing an email to one department.
+
+For balanced datasets, accuracy tells you enough. For imbalanced or skewed datasets (where one class dominates), you need F1 score, precision, and recall to understand whether the agent is actually performing well on the minority classes or just predicting the majority class every time.

--- a/06-production-evaluation-patterns/objective/structured-output-judge/README.md
+++ b/06-production-evaluation-patterns/objective/structured-output-judge/README.md
@@ -1,0 +1,5 @@
+# Structured Output with LLM-as-Judge
+
+Sometimes your agent produces structured output (JSON, a filled form, a schema-conforming response) and you use an LLM-as-judge to verify correctness. This is still objective evaluation because there is a concrete, tangible expected output to compare against.
+
+The difference from free-form LLM-as-judge (which is subjective) is that here the judge has a reference answer or schema to check against. It is verifying facts, field values, and structural correctness, not making a taste judgment. Examples: extracting structured data from documents, filling out forms from conversations, or generating API call parameters.

--- a/06-production-evaluation-patterns/subjective/README.md
+++ b/06-production-evaluation-patterns/subjective/README.md
@@ -1,0 +1,10 @@
+# Subjective Agents
+
+A subjective agent produces outputs where there is no single correct answer. The quality of the output depends on human judgment, taste, and domain expertise. You cannot write a formula to determine if the output is "right." Examples: deep research agents, website builders, slide generators, creative writing assistants, and general-purpose chat agents.
+
+The challenge is: how do you evaluate something that has no ground truth? The answer is to make the subjective as structured and repeatable as possible, without pretending it is objective. There are two main approaches:
+
+- **Checklist-based rubrics** - Break "is it good?" into a weighted list of specific criteria. For example, a deep research report might score +2 points for mentioning a key concept, +5 points for covering a critical detail. The LLM judge checks each item and gives you a numeric score. The checklist is different for every agent and use case, but the pattern is the same: define what matters, weight it, score against it.
+- **Human alignment** - The checklist itself needs to be calibrated against what domain experts actually care about. Collect human ratings, compare them to your automated scores, and check the correlation. What matters is not that the exact scores match, but that they are directionally the same. If the agent scores three items as 7, 10, and 9, and the human scores them 6, 9, and 8, the correlation is near perfect. As long as both agree on which outputs are better and which are worse, your evaluation is working properly. Track this correlation over time as the system evolves.
+
+Navigate into the subfolders for detailed examples and implementation patterns.

--- a/06-production-evaluation-patterns/subjective/checklist-based-rubrics/README.md
+++ b/06-production-evaluation-patterns/subjective/checklist-based-rubrics/README.md
@@ -1,0 +1,29 @@
+# Checklist-Based Rubrics
+
+When you cannot reduce evaluation to a single number, break it into a checklist. Each item on the checklist is a specific, answerable question about the output. This turns a vague "is it good?" into a set of concrete criteria that you can score.
+
+## Example: Deep Research Agent
+
+Say you have a deep research agent. You ask it: "How does Amazon Bedrock AgentCore handle security isolation between users when multiple agents share the same runtime infrastructure?"
+
+This is a real research question that requires synthesizing information across multiple parts of the AgentCore documentation: Runtime sessions, microVM isolation, IAM authentication, Policy enforcement via Cedar, and Gateway interceptors. The agent explores, follows different paths, and produces a report. Every time you invoke the agent, the report will be different because it can approach the topic from different angles. There is no single correct answer. But what matters is: does it contain the facts that are important for this topic?
+
+This is where the checklist comes in. You define the things that matter for this particular question, and you weight them:
+
+| Checklist item | Weight |
+|---|---|
+| Mentions that each session runs in a dedicated microVM with isolated CPU, memory, and filesystem | +5 points |
+| Explains that after session termination, the microVM is destroyed and memory is sanitized | +4 points |
+| Covers inbound authentication (SigV4 or OAuth 2.0 token validation before requests reach the agent) | +3 points |
+| Mentions Policy in AgentCore using Cedar to enforce fine-grained tool access per principal | +4 points |
+| Explains that Gateway interceptors can inspect and block requests before they reach tool targets | +3 points |
+| Notes that sessions are identified by runtimeSessionId and a new session ID after termination creates a fresh environment | +2 points |
+| Mentions that session state is ephemeral and long-term durability requires AgentCore Memory | +2 points |
+
+Total possible: 23 points.
+
+When you evaluate, the LLM judge goes through the output and checks each item. One report might cover microVM isolation and Cedar policies (+9 points). Another might cover all seven items (+23 points). You now have a numeric score for something that seemed entirely subjective, because you broke it down into the things that matter for this question.
+
+## The key point
+
+The specific checklist items and their weights will be different for every agent you build and for every question you evaluate against. A deep researcher about AgentCore security has different criteria than a deep researcher about AgentCore pricing or AgentCore Memory strategies. The pattern is the same (define what matters, weight it, score against it), but the content of the checklist is specific to your agent and your use case. You are the one who defines what "good" looks like for your particular problem.

--- a/06-production-evaluation-patterns/subjective/human-alignment/README.md
+++ b/06-production-evaluation-patterns/subjective/human-alignment/README.md
@@ -1,0 +1,19 @@
+# Human Alignment
+
+Once you have a [checklist-based rubric](../checklist-based-rubrics/README.md) and an LLM judge scoring your agent's outputs, you need to verify that the automated scores actually agree with what a human expert thinks. This is the calibration loop.
+
+## The process
+
+1. **Get human scores.** Take ~20 sample outputs from your agent and ask a domain expert to score each one. Use a simple scale (1-5 or 1-10), then normalize to 0-1 by dividing by the max. So a score of 7 out of 10 becomes 0.7. You now have 20 normalized human scores between 0 and 1.
+
+2. **Get agent scores.** Run the same 20 samples through your checklist-based rubric (the LLM judge). Normalize the output the same way: divide the total points scored by the maximum possible points. You now have 20 normalized agent scores between 0 and 1.
+
+3. **Check correlation.** Compare the two sets of scores. What matters is not that they are identical, but that they are directionally aligned. If the human gives sample A a higher score than sample B, does the agent agree? Compute the correlation. If it is high (e.g. 0.85+), your rubric is well-calibrated.
+
+4. **Iterate.** If the correlation is low, look at where the disagreements are. Is the LLM judge missing something the human cares about? Add it to the checklist. Is the LLM judge over-weighting something the human does not care about? Reduce the weight or remove it. Then re-run and check correlation again.
+
+5. **Repeat until satisfied.** Keep iterating the checklist items, their weights, and the LLM-as-judge prompt until the correlation with human judgment is at a level you are comfortable with for your use case.
+
+## Why this works
+
+You are not trying to replace human judgment. You are building a trusted proxy that agrees with human judgment often enough that you can run it at scale. A human can only review so many outputs in a day. By doing this calibration work upfront and iterating over time, you make yourself so much more scalable while keeping the performance bar high. You are not flying blind. You have evidence that the LLM judge agrees with your experts, which means you can trust it to evaluate thousands of outputs that no human would ever have time to review. This is what makes your agents trustworthy at production scale.

--- a/07-production-lifecycle/README.md
+++ b/07-production-lifecycle/README.md
@@ -1,0 +1,17 @@
+# Production Lifecycle
+
+Your agent is deployed and serving real users. Now what? This module covers how to safely evolve a production agent over time: updating system prompts, rolling out changes without breaking things, monitoring for regressions, and responding when something goes wrong.
+
+**The core pattern is: make a change, validate it is better or at least not worse, then promote or rollback.**
+
+How you validate depends on your setup. You might run internal evals against your most common use cases, compare old vs new outputs with LLM-as-judge or human review, and ship directly to production if the results are good. Or you might A/B test by routing a small percentage of live traffic to the new version and measuring in production. Or both. The right approach depends on how good your offline evaluation is, your risk tolerance, and the agent use case.
+
+In production, agents have to solve for a business case. That means you will inevitably face scenarios like:
+
+- **Updating the system prompt** - You want to add a new capability or change how the agent behaves. How do you validate the new prompt does not regress on existing behavior?
+- **Swapping a backend API** - Your research agent uses Brave Search but you want to switch to a different SERP API. To the agent, nothing has changed. The tool interface is identical. But internally, the backend is different and the results may differ. How do you ensure quality stays the same?
+- **Modifying tool schemas** - Tool schemas define how your agent parses input and passes it to the tool. Changing the input structure, output structure, or description changes how the agent interacts with your infrastructure. Small schema changes can shift behavior in unpredictable ways.
+- **Optimizing model selection for cost and performance** - The agent works great on Opus 4.7 but costs too much. How do you get the same performance with a smaller, cheaper model like Sonnet or Haiku?
+- **Reducing latency** - Smaller models are faster. How do you find the sweet spot where the agent is both quick and capable enough for your use case?
+
+Each of these is a real scenario that production teams face. The subfolders here cover the mechanisms (A/B testing, weighted routing, monitoring, alerting) for handling these changes safely.

--- a/07-production-lifecycle/ab-testing/README.md
+++ b/07-production-lifecycle/ab-testing/README.md
@@ -1,0 +1,22 @@
+# A/B Testing
+
+You have two versions of the same agent. Maybe version B has a new tool, a new feature, a change to the system prompt, or a different model. You have run your offline evaluations and testing looks good. Now you are ready to take this to production. But do you just flip from A to B for everyone at once?
+
+The better approach is A/B testing. You turn on the new version for a certain percentage of your users, say 10%, and keep the remaining 90% on the proven version. Those 10% of users interact with the new agent in production, and you monitor those conversations, observe the outputs, and check that the new version is performing well on real traffic. Once you are comfortable, you increase the percentage. If something goes wrong, you route everyone back to version A.
+
+## Design your systems for change
+
+The most important takeaway is not the A/B test itself, but the principle behind it: **design your systems in a way that you can serve a certain part of your user base with new changes.** If your architecture does not support routing different users to different agent versions, you are stuck with all-or-nothing deployments. That is risky.
+
+This means building your system with a routing layer (feature flags, traffic splitting, or gateway rules) that lets you:
+
+- Serve the updated agent to a subset of the population
+- Monitor those conversations separately from the baseline
+- Roll back instantly if the new version underperforms
+- Gradually increase traffic as confidence grows
+
+This is not just about testing. It is about making your production agent systems resilient to change. Agents evolve constantly (new prompts, new tools, new models), and the teams that ship safely are the ones who built the infrastructure to do partial rollouts from day one.
+
+## What to measure
+
+"Better" for agents is often multi-dimensional: faster, more accurate, more helpful, cheaper. Pick which metrics are your primary decision criteria upfront. Do not change multiple things at once or you will not know what caused the difference. Monitor the new version against the same evaluation criteria you used in your offline evals, but now on real user traffic.

--- a/07-production-lifecycle/alerting/README.md
+++ b/07-production-lifecycle/alerting/README.md
@@ -1,0 +1,28 @@
+# Alerting
+
+Agents fail differently than traditional software. In traditional software, a failed API call throws an error and the user sees an error page. With agents, failures are often implicit rather than explicit. If a tool's API runs out of credits, the tool stops working, but the agent does not necessarily crash. It might move on to the next tool, skip the step, or give a substandard output without raising a visible failure. The user gets a worse answer, but nobody gets paged.
+
+This is why alerting for agents needs to go beyond error rates. You need to monitor tool-level success rates and set thresholds that catch degradation before it compounds.
+
+## Example: Tool pass rate threshold
+
+Say your agent uses a search API tool. You set up a CloudWatch metric tracking tool call success/failure. If the tool has failed 5 out of the last 10 calls, that crosses your threshold. An alarm fires, sends a notification to Slack (via SNS), and the on-call team investigates. They discover the search API ran out of credits. They top it up, and the agent goes back to normal.
+
+Without that alert, you might not notice for a day or two. In the meantime, every user interaction that needed search is getting substandard results, and nobody knows.
+
+## How to implement this
+
+The practical approach is to handle exceptions explicitly in your codebase. When a tool call fails with a specific error (API out of credits, rate limited, timeout), raise and catch that exception, and have that exception trigger an alert. For example, if your search API returns a 402 or 429, catch it, log it as a structured event, and send a Slack notification via SNS. Do not let the agent silently absorb the failure and try to continue without the tool's output.
+
+If you let tool failures pass silently, the agent will try to achieve the outcome anyway. Without the data it needed, it starts to hallucinate and make things up. To the user, the experience suddenly feels broken. "What happened to the agent? It used to be good and now it is making stuff up." That is the worst kind of failure because it erodes trust gradually rather than failing loudly.
+
+## What to alert on
+
+- **Tool call failure rate** - If a specific tool fails above a threshold (e.g. 50% failure over 10 calls), something is wrong with that tool's backend.
+- **Specific exception types** - API credit exhaustion, authentication failures, rate limiting. Each should have its own alert path to the right team.
+- **Latency spikes** - If a tool or the overall agent response time spikes, it could indicate rate limiting, cold starts, or downstream degradation.
+- **Cost anomalies** - If token usage or API costs spike unexpectedly, something changed in the agent's behavior (e.g. looping, excessive retries).
+
+## The goal
+
+Be proactive rather than reactive. Design your alerting so that you catch failures explicitly in code, route them to the right team, and fix them before users notice. Alerting is not optional for production agents. It is what keeps your agent trustworthy.

--- a/07-production-lifecycle/monitoring-and-usage/README.md
+++ b/07-production-lifecycle/monitoring-and-usage/README.md
@@ -1,0 +1,36 @@
+# Monitoring and Usage
+
+Continuous monitoring is not just about catching errors. It is about having full visibility into how your agent is being used, how it is performing, and whether users are actually getting value from it over time.
+
+## What to log
+
+Log every agent interaction: the input, the output, which tools were called, how long each step took, token usage, and which model version was used. This is the raw data that everything else is built on. If you do not log it, you cannot debug it, dashboard it, or replay it later.
+
+## Dashboards
+
+Set up time-series dashboards for the metrics that matter:
+
+- **Latency** - End-to-end response time and time to first token. Are users waiting too long?
+- **Error rates by tool** - Which tools are failing and how often? Trends over days and weeks.
+- **Token usage and cost** - Is cost per session stable, or is something making the agent use 3x more tokens than last week?
+- **Invocation volume** - How many times is the agent being called per day/week?
+
+## User behavior and retention
+
+Technical metrics tell you if the agent is working. Usage metrics tell you if it is useful.
+
+- **Are users coming back?** Track retention. Are users invoking the agent every day, or do they try it once and never return?
+- **How often per user?** If a user invokes the agent 5 times a day, that is a strong signal. If they do it once a week, maybe the agent is not solving enough for them.
+- **Is usage trending up or down?** A slow decline in daily invocations is a signal that something is off, even if no single alert fires.
+
+These are the signals that tell you whether your agent is actually delivering value, not just running without errors.
+
+## Replay and debugging
+
+A user will come back and say "the agent gave me a wrong answer" or "it said something I did not expect." At that point, you need to be able to go back to that exact conversation, see the state of the system at that moment, and understand exactly what happened. What was the input? What tools were called? What context was available? What did the model return? What was the system prompt at that time?
+
+If you have not logged the state of the system, you will never be able to debug it, and you will never be able to go back to the user with an explanation or a fix. Logging everything is not optional. It is what makes your agent debuggable and your team accountable.
+
+## Periodic quality checks
+
+Pick 10 samples from the past week's traffic, re-run them through your LLM-as-judge rubric, and check that quality is holding. This is not real-time alerting. It is a weekly sanity check that catches slow drift: the agent getting slightly worse over time in ways that no single failure would surface.

--- a/08-rag-evaluation/README.md
+++ b/08-rag-evaluation/README.md
@@ -1,0 +1,8 @@
+# RAG Evaluation
+
+RAG (Retrieval-Augmented Generation) has two distinct steps, and each one needs to be evaluated separately:
+
+1. **Retrieval** - Finding the right chunks from your knowledge base. This is objective. You can measure it with precision and recall: did you find the right chunks, and how many of the relevant ones did you get? This is the same pattern as multi-label classification.
+2. **Generation** - Using an LLM to synthesize an answer from the retrieved chunks. This is where it gets subjective. Was the answer well-written? Did it actually use the context? Did it hallucinate beyond what was retrieved?
+
+Because these two steps require completely different evaluation strategies, you should never only measure the final output. If the chunks were never retrieved properly, the model was never given the right context, and the final answer can never be as good. That is a retrieval problem. On the other hand, if the right chunks were retrieved but the final answer fails to follow the tone, branding, or style you expect, that is a generation problem. Separating these two tells you where to focus your effort. The subfolders here break this down layer by layer.

--- a/08-rag-evaluation/answer-synthesis/README.md
+++ b/08-rag-evaluation/answer-synthesis/README.md
@@ -1,0 +1,5 @@
+# Answer Synthesis Evaluation
+
+Answer synthesis evaluates the quality of the final generated response, assuming retrieval and grounding are already correct. This is the subjective layer of RAG: was the answer well-written, did it combine multiple sources coherently, and did it actually address the user's question?
+
+This layer uses the same techniques as subjective agent evaluation: checklist-based rubrics, LLM-as-judge with explicit criteria, and human review for calibration. The difference from general subjective evaluation is that you have the retrieved context as additional input, so the judge can check relevance and completeness against the available information.

--- a/08-rag-evaluation/chunking/README.md
+++ b/08-rag-evaluation/chunking/README.md
@@ -1,0 +1,5 @@
+# Chunking Evaluation
+
+Chunking is the preprocessing step: how you split documents into pieces before indexing them. Bad chunks lead to bad retrieval regardless of how good your retriever is.
+
+Evaluate chunking by checking: are semantic boundaries preserved (do chunks contain complete thoughts rather than cutting mid-sentence), is the chunk size appropriate for your embedding model's context window, and do chunks retain enough context to be useful in isolation? This is often evaluated qualitatively during development rather than with automated metrics, but poor chunking is a common root cause of RAG failures.

--- a/08-rag-evaluation/end-to-end/README.md
+++ b/08-rag-evaluation/end-to-end/README.md
@@ -1,0 +1,5 @@
+# End-to-End Evaluation
+
+End-to-end evaluation treats the RAG pipeline as a black box: given a question, did the system produce the right answer? This does not tell you which component failed, but it tells you whether the system works from the user's perspective.
+
+Use this as a top-level smoke test and regression check. Maintain a set of question-answer pairs with known correct answers. Run them through the full pipeline periodically and flag any regressions. When an end-to-end test fails, drill into the per-layer evaluations (retrieval, grounding, synthesis) to diagnose the root cause.

--- a/08-rag-evaluation/grounding/README.md
+++ b/08-rag-evaluation/grounding/README.md
@@ -1,0 +1,5 @@
+# Grounding Evaluation
+
+Grounding checks whether the LLM actually used the retrieved context rather than hallucinating or relying on its parametric knowledge. The question is: can every claim in the response be traced back to the retrieved chunks?
+
+This is semi-objective. You can decompose the response into individual claims, then verify each claim against the provided context. An LLM judge works well here because the task is constrained: "is this specific claim supported by this specific text?" It is not a taste judgment, it is a verification task with a clear yes/no answer per claim.

--- a/08-rag-evaluation/retrieval/README.md
+++ b/08-rag-evaluation/retrieval/README.md
@@ -1,0 +1,5 @@
+# Retrieval Evaluation
+
+Retrieval evaluation is the most objective part of RAG. Given a query, did you retrieve the right chunks? This maps directly to precision and recall, the same way multi-label classification works: of the chunks you returned, how many were relevant (precision), and of all the relevant chunks that exist, how many did you find (recall)?
+
+Standard IR metrics apply: precision@k, recall@k, NDCG, MRR. You need a ground truth dataset mapping queries to their relevant chunks. Build this by hand for your most important query types and expand it over time as you review production traffic.


### PR DESCRIPTION
## Summary

- Add `06-production-evaluation-patterns/` covering objective (classification, regression, structured output) and subjective (checklist-based rubrics, human alignment) agent evaluation strategies
- Add `07-production-lifecycle/` covering A/B testing, alerting for implicit agent failures, and monitoring/usage tracking
- Add `08-rag-evaluation/` setting up the structure for evaluating RAG pipelines layer by layer (chunking, retrieval, grounding, answer synthesis, end-to-end)

## Note

This PR sets up the structure and philosophy for these modules. RAG evaluation content will be expanded in a follow-up PR.